### PR TITLE
Add keyword/selection history handlers

### DIFF
--- a/app.js
+++ b/app.js
@@ -47,4 +47,73 @@ export const searchArtistByKeyboard = async (keyword) => {
     } catch (error) {
         console.error('Search Error:', error.message);
     }
+
+};
+
+//show keyword history
+//This function lets users see past search keywords and run a search again:
+export const showKeywordHistory = async () => {
+    try {
+        const keywords = await db.find('search_history_keyword');
+
+        if (!keywords.length) {
+            console.log('No keyword history found.');
+            return;
+        }
+
+        const { keyword } = await inquirer.prompt([
+            {
+                type: 'list',
+                name: 'keyword',
+                message: 'Select a keyword to search again or Exit:',
+                choices: ['Exit', ...keywords.map(k => k.keyword)],
+            }
+        ]);
+
+        if (keyword !== 'Exit') {
+            await searchArtistByKeyboard(keyword);
+        }
+
+    } catch (err) {
+        console.error('Keyword History Error:', err.message);
+    }
+};
+
+//showSelectionHistory
+//This lets users see artists they've previously selected
+export const showSelectionHistory = async () => {
+    try {
+        const selections = await db.find('search_history_artist');
+
+        if (!selections.length) {
+            console.log('No artist selection history found.');
+            return;
+        }
+
+        const { artistId } = await inquirer.prompt([
+            {
+                type: 'list',
+                name: 'artistId',
+                message: 'Select an artist or Exit:',
+                choices: ['Exit', ...selections.map(a => ({
+                    name: `${a.name} (${a.genres?.join(', ') || 'Unknown'})`,
+                    value: a.id
+                }))],
+            }
+        ]);
+
+        if (artistId !== 'Exit') {
+            const artist = selections.find(a => a.id === artistId);
+            printArtist({
+                name: artist.name,
+                genre: artist.genres?.join(', ') || 'Unknown',
+                popularity: artist.popularity,
+                followers: artist.followers?.total || artist.followers,
+                url: artist.external_urls?.spotify || artist.url,
+            });
+        }
+
+    } catch (err) {
+        console.error('Selection History Error:', err.message);
+    }
 };


### PR DESCRIPTION
Added showSelectionHistory and show keyword history functions for the app.js file.

The showKeywordHistory function lets users see past search keywords and run a search again.
The showSelectionHistory function should let users see artists they've previously selected. 

I may modify after the cli.js is updated.
